### PR TITLE
Fixes disconnected depth_mask input in openni source

### DIFF
--- a/python/ecto_image_pipeline/io/source/openni.py
+++ b/python/ecto_image_pipeline/io/source/openni.py
@@ -30,6 +30,7 @@ class OpenNISource(ecto.BlackBox):
     def connections(self, _p):
         keys = ('depth', 'image', 'focal_length_image', 'focal_length_depth', 'baseline')
         #camera model
-        graph = [ self.source[keys] >> self.converter[keys] ]
+        graph = [ self.source[keys] >> self.converter[keys],
+                  self.source['depth'] >> self.depth_mask['depth'] ]
 
         return graph


### PR DESCRIPTION
Appears to have been disconnected in https://github.com/plasmodic/ecto_image_pipeline/commit/cdaaeeba0050374c4365833616680ab528bb0255

Lack of depth mask appears to break ORK orb_template tools.
